### PR TITLE
Add VS Code MCP server configurations

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,34 @@
+{
+  "servers": {
+    "chakra-ui": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@chakra-ui/react-mcp"]
+    },
+    "react-icons": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "react-icons-mcp", "--stdio"]
+    },
+    "next-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp"]
+    },
+    "crowdin": {
+      "type": "http",
+      "url": "https://mcp.crowdin.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${input:crowdin-token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "crowdin-token",
+      "description": "Crowdin Personal Access Token",
+      "password": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds .vscode/mcp.json with four MCP servers to improve AI-assisted
development in VS Code with GitHub Copilot:
- @chakra-ui/react-mcp: component props, examples, theme tokens
- react-icons-mcp: search/discover icons from react-icons libraries
- next-devtools-mcp: Next.js error detection and dev server insights
- crowdin (hosted HTTP): manage translations, projects, and glossaries

https://claude.ai/code/session_01NJDNXB9cDmRZ9BHWJcGUio