### PR TITLE
ci: add Chromatic visual regression workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,57 @@
+name: Chromatic
+
+on:
+  pull_request:
+    branches: [main, modernize-updates]
+  push:
+    branches: [main, modernize-updates]
+
+# Visual regression baselines for the Storybook section stories. This is the gate the
+# redesign (PR2) leans on: it catches unintended visual drift that lint/typecheck/build
+# structurally cannot see.
+jobs:
+  chromatic:
+    name: Visual regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Chromatic diffs against a baseline commit, so it needs full history —
+          # a shallow clone makes it unable to find the ancestor build.
+          fetch-depth: 0
+
+      # Bun drives install + scripts. Version pinned to match packageManager in package.json.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      # Node 24 LTS runtime for the tools bun invokes (chakra typegen needs Node >= 20.6.0).
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate theme typings
+        run: bun run theme
+
+      # Build with bun ourselves rather than handing Chromatic a buildScriptName: the
+      # action shells out to a detected package manager (npm/yarn/pnpm) and this repo is
+      # bun-only. Publishing a prebuilt static dir sidesteps that entirely.
+      - name: Build Storybook
+        run: bun run build-storybook
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v18
+        with:
+          # Set as a repo secret — never commit the project token.
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: storybook-static
+          # Visual changes are frequently intentional (the redesign is next), so don't
+          # fail the job on them. Chromatic posts its own "UI Tests" check, which stays
+          # pending until the diffs are accepted — that is the actual review gate.
+          exitZeroOnChanges: true

--- a/.storybook/fonts.css
+++ b/.storybook/fonts.css
@@ -1,0 +1,18 @@
+/*
+ * Mirrors the :root font vars _app.tsx defines. These MUST live at :root — not on a
+ * wrapper element inside the decorator.
+ *
+ * The theme sets fonts.heading: "var(--font-tw)", which Chakra emits at :root as
+ * `--chakra-fonts-heading: var(--font-tw)`. A custom property whose value contains
+ * var() is substituted at computed-value time *on the element where it is declared*.
+ * So --chakra-fonts-heading resolves against :root; if --font-tw is only defined on a
+ * descendant div, the token has already computed to invalid and that empty value
+ * inherits down — every font token renders undefined, no matter what the div says.
+ *
+ * Defining them here also covers portalled content (tooltips render into document.body,
+ * outside any decorator wrapper).
+ */
+:root {
+  --font-tw: "Titillium Web", sans-serif;
+  --font-mulish: "Mulish", sans-serif;
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,15 +3,22 @@ import type { Preview } from "@storybook/react-vite";
 import { ChakraProvider } from "@chakra-ui/react";
 import { I18nextProvider } from "react-i18next";
 
+// Register the @font-face rules, mirroring _app.tsx. Declaring the family names in
+// fontVars below is not enough on its own — without these imports nothing loads the
+// actual files, so any machine that lacks the fonts locally (e.g. Chromatic's Linux
+// capture container) silently falls back to a system font. Keep the weights in sync
+// with _app.tsx so Storybook renders what production renders.
+import "@fontsource/titillium-web/700.css";
+import "@fontsource/mulish/400.css";
+
 import theme from "../src/lib/theme";
 import i18n from "./i18n";
 
-// The app injects these font CSS vars from next/font in _app.tsx. Storybook can't fetch
-// Google Fonts offline, so supply static fallbacks under the same var names the theme
-// references (var(--font-tw) / var(--font-mulish)).
+// The theme references these var names (var(--font-tw) / var(--font-mulish)); the app
+// defines them on :root in _app.tsx. Same stacks here so Storybook matches production.
 const fontVars = {
-  "--font-tw": "'Titillium Web', system-ui, sans-serif",
-  "--font-mulish": "'Mulish', system-ui, sans-serif",
+  "--font-tw": '"Titillium Web", sans-serif',
+  "--font-mulish": '"Mulish", sans-serif',
 } as React.CSSProperties;
 
 const preview: Preview = {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,25 +1,19 @@
-import * as React from "react";
 import type { Preview } from "@storybook/react-vite";
 import { ChakraProvider } from "@chakra-ui/react";
 import { I18nextProvider } from "react-i18next";
 
-// Register the @font-face rules, mirroring _app.tsx. Declaring the family names in
-// fontVars below is not enough on its own — without these imports nothing loads the
-// actual files, so any machine that lacks the fonts locally (e.g. Chromatic's Linux
-// capture container) silently falls back to a system font. Keep the weights in sync
-// with _app.tsx so Storybook renders what production renders.
+// Register the @font-face rules, mirroring _app.tsx. Without these nothing loads the
+// actual files, so any machine lacking the fonts locally (e.g. Chromatic's Linux capture
+// container) silently falls back to a system font. Keep the weights in sync with
+// _app.tsx so Storybook renders what production renders.
 import "@fontsource/titillium-web/700.css";
 import "@fontsource/mulish/400.css";
+// Defines --font-tw / --font-mulish at :root, which is where the theme's font tokens
+// resolve them. See the file for why a decorator-level wrapper cannot work.
+import "./fonts.css";
 
 import theme from "../src/lib/theme";
 import i18n from "./i18n";
-
-// The theme references these var names (var(--font-tw) / var(--font-mulish)); the app
-// defines them on :root in _app.tsx. Same stacks here so Storybook matches production.
-const fontVars = {
-  "--font-tw": '"Titillium Web", sans-serif',
-  "--font-mulish": '"Mulish", sans-serif',
-} as React.CSSProperties;
 
 const preview: Preview = {
   parameters: {
@@ -41,9 +35,7 @@ const preview: Preview = {
     (Story) => (
       <I18nextProvider i18n={i18n}>
         <ChakraProvider theme={theme}>
-          <div style={fontVars}>
-            <Story />
-          </div>
+          <Story />
         </ChakraProvider>
       </I18nextProvider>
     ),


### PR DESCRIPTION
Adds a Chromatic workflow so the Storybook section stories get a visual baseline. This is the gate the redesign leans on: **visual drift is exactly the class of regression `lint`/`typecheck`/`build` cannot see** — a lesson PR1 made concrete, where all four gates passed while 16 real visual/token regressions sat in the diff.

Based off `modernize-updates` because Chromatic needs Storybook, which landed there in PR0 (`@chromatic-com/storybook` is already a devDependency).

## Design decisions

**Prebuilt Storybook instead of `buildScriptName`.** The Chromatic action shells out to a *detected* package manager (npm/yarn/pnpm) to run the build script; this repo is bun-only. Building with `bun run build-storybook` and handing the action `storybookBuildDir: storybook-static` sidesteps package-manager detection entirely.

**`fetch-depth: 0`.** Chromatic resolves its baseline from git ancestry — a shallow clone leaves it unable to find the ancestor build.

**`exitZeroOnChanges: true`.** Visual changes are frequently intentional (the redesign is next), so the job doesn't red-X on them. Chromatic posts its own **UI Tests** check, which stays pending until diffs are accepted — that's the actual review gate, not this job's exit code.

**`bun run theme` before the build**, matching `ci.yml` — Storybook needs the generated Chakra typings.

## Token handling

The project token is stored as the **`CHROMATIC_PROJECT_TOKEN` repo secret** (already set) and read via `${{ secrets.CHROMATIC_PROJECT_TOKEN }}`. It is not committed anywhere — verified by grep across the tree.

⚠️ One consequence worth knowing: `pull_request` runs from **forks** don't receive secrets, so this job would fail there with an empty token. Fine for a personal repo where PRs come from local branches; worth revisiting if outside contributions ever start.

## Notes

- Pinned to `chromaui/action@v18` (current major) and mirrors `ci.yml`'s bun 1.3.14 / Node 24 setup.
- The first run on the base branch establishes the baseline — expect it to accept everything as new.
- **TurboSnap (`onlyChanged: true`) deliberately not enabled** for this initial wiring: it needs extra Vite stats plumbing and is a known source of flakiness. Worth adding later to conserve snapshot quota once baselines are stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUm1EasF9AhoPsWakTL1rA