### PR TITLE
ci: sync main's v7 action bumps into modernize-updates

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Chromatic diffs against a baseline commit, so it needs full history —
           # a shallow clone makes it unable to find the ancestor build.
@@ -29,7 +29,7 @@ jobs:
 
       # Node 24 LTS runtime for the tools bun invokes (chakra typegen needs Node >= 20.6.0).
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Bun drives install + scripts. Version pinned to match packageManager in package.json.
       - name: Setup Bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Node 24 LTS runtime for the tools bun invokes (next build, chakra typegen — needs Node >= 20.6.0).
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 


### PR DESCRIPTION
Follow-up to Dependabot #15/#16, which landed `actions/checkout@v7` and `actions/setup-node@v7` on `main`.

## Why this is needed

**Merging those PRs alone wasn't sufficient — it set up a silent revert.** `modernize-updates` still pinned `@v4`, so when the integration branch eventually merges to `main`, it would have **undone both bumps** without anything flagging it. This merges `main` in so the integration line carries them forward.

## Two changes

1. **Merge `main` → this branch** — brings the `@v7` bumps into `ci.yml`. Clean automerge: the v7 pins land while PR0's `Build Storybook` step is preserved.
2. **Bump `chromatic.yml` to `@v7`** by hand. **Dependabot structurally cannot propose this one:** the `github-actions` ecosystem only scans workflows on the **default branch**, and `chromatic.yml` exists only on `modernize-updates` until the final integration merge. Left alone, its pins would drift unmanaged through the whole redesign.

Net: no `actions/checkout` or `actions/setup-node` below v7 in any workflow.

## Risk

Low, and evidence-backed rather than assumed:
- v7 of both is current; the changes are ESM migration + dependency upgrades. `checkout@v7` also blocks fork checkout for `pull_request_target`/`workflow_run` — neither of which this repo uses.
- **#15/#16 both passed CI while running the bumped action**, so the bump is proven against this exact bun/Node 24 setup.
- CI + Chromatic run on this PR, re-proving it against the integration branch (now on Chakra v3).

## Note for later

Once `chromatic.yml` reaches `main` (at the final integration PR), Dependabot picks it up automatically and this manual step stops being necessary. If the redesign runs long and you'd rather not have it drift until then, a `target-branch: modernize-updates` entry in `dependabot.yml` would cover it — deliberately not done here to avoid extra PR noise on a temporary branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUm1EasF9AhoPsWakTL1rA