### PR TITLE
feat: PR2 shared redesign substrate (theme, anchor contract, fonts, data)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "configurations": [
+    {
+      "name": "Storybook",
+      "type": "storybook",
+      "command": "bunx storybook dev --port $PORT --ci",
+      "cwd": ".",
+      "autoPort": true
+    }
+  ]
+}

--- a/.claude/rules/chakra-v3.md
+++ b/.claude/rules/chakra-v3.md
@@ -135,6 +135,33 @@ Only sub-keys that actually collide matter: `bg.canvas` / `bg.surface` / `bg.ban
 `fg.default` do **not** collide (v3 owns `bg.subtle`, `fg.DEFAULT`, etc.), so they are
 fine as plain tokens.
 
+### `DEFAULT` (uppercase) is the BARE-name key — `default` mints a dead sibling
+
+v3's convention for "the value you get from the bare token name" is the uppercase key
+**`DEFAULT`**. `#22` wrote it lowercase:
+
+```ts
+fg: { default: "…" }   // WRONG — mints colors.fg.default, referenced NOWHERE in src/
+fg: { DEFAULT: "…" }   // RIGHT — registers the bare `colors.fg`
+```
+
+Lowercase `default` is treated as an ordinary sub-key: it creates a real-but-dead
+`fg.default` token AND leaves the bare `fg` sitting on v3's default `_light` value — a
+**black** `<html>` fg, masked on this site only by body's white. Same trap for `bg`.
+Unlike `base` in semanticTokens (which *collapses* onto its parent), `DEFAULT` does not
+collapse a lowercase sibling — the two coexist and the dead one typechecks clean. Fixed in
+PR2: both `fg` and `bg` now resolve at **1 condition**.
+
+### The "1 condition = clean" heuristic has a second exception: plain `radii` overrides
+
+The condition-count probe (`>1 = a v3 default contends`) assumes the failure mode is a
+specificity contest. It is not the only one. A plain-token override of `radii.l1/l2/l3`
+reports **1 condition and is still dead** — the value never enters the registry at all, so
+the emitted var stays `var(--chakra-radii-sm)`. Different failure class from the colors
+case: nothing to out-specify, the token simply isn't registered. **Use `semanticTokens`
+for radii overrides**, and confirm the computed `border-radius` on a real widget — 1
+condition does not clear it here.
+
 ## v3 merges default recipes that v2 never had
 
 v2's `extendBaseTheme` **emptied** `components`, so our recipes were the only component

--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -48,6 +48,14 @@ lands.
   - **A green a11y run is not "this section is accessible" — it is "the mounted parts
     are."** Axe cannot see a `lazyMount`/`unmountOnExit` subtree. Give such subtrees their
     own story; do not infer coverage from a green tick.
+  - **Axe silently DECLINES to measure contrast past an undeterminable backdrop — green
+    there is absence-of-measurement, not a pass.** `AboutMeSection` has the identical
+    4.29:1 body-on-legacy-teal that CI *did* fail in `ReachOutSection`, yet axe stayed
+    green on AboutMe. Verified directly: drop the `color="body"` pin and the a11y run still
+    passes. Its skewed `::before` (`position:relative` + `zIndex:-1` + inset `boxShadow`)
+    leaves the effective background undeterminable, so axe reports nothing rather than a
+    violation. A contrast rule that cannot resolve the backdrop yields silence, not a flag
+    — pin such sections by hand and confirm the ratio yourself; do not trust the green.
   - **KNOWN OPEN GAP — `ProjectItemCard` is unchecked by anything.** It is behind
     `ProjectsSection`'s lazyMounted Projects tab, so no story mounts it: axe never sees it,
     Chromatic has never baselined it, and the `next/image` `define` in `main.ts` is

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -28,8 +28,13 @@ trackFocusVisible();
 // actual files, so any machine lacking the fonts locally (e.g. Chromatic's Linux capture
 // container) silently falls back to a system font. Keep the weights in sync with
 // _app.tsx so Storybook renders what production renders.
+// Keep IDENTICAL to src/pages/_app.tsx — see the note there for which weights are
+// used and why the design's font link is not the source of truth.
+import "@fontsource/titillium-web/600.css";
 import "@fontsource/titillium-web/700.css";
 import "@fontsource/mulish/400.css";
+import "@fontsource/mulish/600.css";
+import "@fontsource/mulish/700.css";
 import "@fontsource/jetbrains-mono/400.css";
 import "@fontsource/jetbrains-mono/500.css";
 // Defines --font-tw / --font-mulish / --font-mono at :root, which is where the theme's

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/REDESIGN_SPECS.md
+++ b/REDESIGN_SPECS.md
@@ -1,0 +1,120 @@
+# PR2 Redesign — Section Specs & Seams Review
+
+_Generated 2026-07-15 from a 7-agent read-only spec pass (6 sections + 1 integration
+reviewer) against `Portfolio.dc.html` / `DesignSystem.dc.html` and the installed Chakra
+v3.36.0. Tree verified untouched afterwards._
+
+Full agent output (261KB, every spec's `structure` / `tokens` / `i18n` / `risks` / `a11y` /
+`storyPlan`):
+`/tmp/claude-1000/-home-tylerapfledderer-web-development-tylerpweb-dev/96a31888-7653-474a-a5c1-1701baf8c82c/tasks/wz1dceu8k.output`
+
+---
+
+## Verified before trusting (I re-checked the claims that overrule a spec)
+
+| Claim | Verdict | Evidence |
+|---|---|---|
+| `createBreakpoints` sorts, so insertion order is irrelevant | **TRUE** | `styled-system/breakpoints.js` → `sort(breakpoints)`. **Hero's "inverted cascade" premise is false.** |
+| Layer order `reset(0) base(1) tokens(2) recipes(3)` | **TRUE** | `styled-system/layers.js`. A `globalCss` link fix **loses to the Link recipe** — a dead fix that typechecks. |
+| Chakra `sm` = 480px, not the design's 640px | **TRUE** | `theme/breakpoints.js:3`. |
+| v3 `Link` default variant is `plain` → `colorPalette.fg` | **TRUE** | `theme/recipes/link.js`. |
+| `gray.fg` → `_light: gray.800` wins with no colour mode | **TRUE** | probed: `_light => var(--chakra-colors-gray-800)`. This is the 1.24:1 mechanism. |
+| `globalCss` paints `html { bg: "background" }` = **#182326**, not `bg.canvas` #0b1617 | **TRUE** | `theme.ts:105`. **Invalidates Hero's whole contrast table.** |
+| A custom `recipes.link` can beat the default | **TRUE (config-time)** | probed: `plain.color` overridden, `base` merge intact (`display`/`gap`/`focusVisibleRing`), `underline` survives. ⚠️ Config-time is **not proof** in this repo — verify in a browser in the shared PR. |
+
+---
+
+## The six sections
+
+**Header** — NEW `src/components/Header.tsx`; sticky blurred bar, gradient TP mark +
+wordmark, nav ≥640px / hamburger + dropdown panel below. Wraps **both** link sets in one
+`<nav>` (the design leaves the panel's links outside the landmark). Two dead-on-arrival
+traps caught in a real browser: `backdropBlur="lg"` + `backdropFilter="auto"` computes to
+**`none`** (eight vars Chakra never defines) — use `backdropFilter="blur({blurs.lg})"`; and
+an unstyled `<Link>` here renders **1.24:1**. Header's audit is the only one the seams
+reviewer could not fault.
+
+**Hero** — left-aligned two-column band at `id="top"`; kicker moves above the h1, graphic
+becomes an inline animated SVG (visible on phone now), scroll notice + `CurvedDownArrow`
+dropped. **Its contrast table is invalid** (measured against #0b1617; the page paints
+#182326) and **its breakpoint reasoning is refuted** — both need redoing before build.
+
+**About** — skewed teal slab → flat `#122527` band, hairlined, two gradient cards. Kills
+`Highlight` (can't paint "beautiful" teal + "useable" amber — one `styles` object for all
+queries) in favour of `<Trans>` + indexed components, which also **closes a live i18n bug**:
+`about-title-highlight-1/-2` need each of 12 translators to emit an exact substring match,
+and a miss silently drops the highlight with every gate green.
+
+**Skills** — decorative scatter → **commit rail**; container query at 820px (not a viewport
+query) swaps chips → SVG rail. Correction: "icons are monochrome" is **false** — all 11 are
+already brand-coloured, 7 via `createIcon` `defaultProps.color`, 4 via hardcoded `fill`, and
+**every one differs from the design's hex**. That's a second source of brand truth, not
+missing data.
+
+**Work** — `bg.band` band, pill toggle, OSS gradient cards + a `minmax` project grid.
+**Keep Chakra `Tabs`; switch `enclosed` → `subtle`.** `segment-group` is a radio group
+(`role="radiogroup"`, real inputs) and would need hand-rolled panel wiring; `plain` is a
+trap — its `[data-selected][data-ssr]` selector is (0,2,0) and a flat `_selected` style prop
+(0,1,0) **cannot beat it**, so SSG would paint a white pill until hydration. Found live: the
+`enclosed` `_selected: { shadow: "xs" }` was never overridden by #22, so **a light-mode drop
+shadow is leaking onto the selected tab in production right now**.
+
+**Contact** — `ReachOutSection` → `ContactSection`, `id="contact"`. **No form** (confirmed:
+three anchors, zero inputs; the mailto pill is the primary action). Drops Twitter and stops
+importing `SocialLinksList`.
+
+---
+
+## Seams — what blocks the fan-out
+
+1. **The footer is unclaimed.** Seven design bands, six specs. Its copy changes
+   ("This site is built with NextJS…" → "Mobile-first · Titillium Web + Mulish") across 13
+   locales and nobody proposed it. It lives in `index.tsx`, so five PRs touch it and none
+   redesign it.
+2. **`SocialLinksList` mutual-orphan bug.** Hero says it's retired; Contact says Hero keeps
+   it alive; Hero's risk note says *Contact* keeps it alive. Each spec's reason for not
+   deleting it is a fact the other spec's PR is about to falsify. If both land: zero
+   consumers, `waggle` dead, nobody deletes either.
+3. **`globalCss` is unowned** and four sections depend on it. It's what invalidates Hero.
+4. **`drawrail` keyframe collision.** Hero and Skills define the same name with incompatible
+   semantics. Resolution: Hero's layer-2 rail is a verified no-op (layer 1 already paints the
+   identical path in the identical colour) — delete it, and Skills' `from`-based fix is safe.
+5. **Four sections, four mechanisms for one breakpoint problem** (640 theme bp / 900 raw
+   at-rule / 820 container query / 900 hardcoded). Settle once.
+6. **`linkRecipe` — the highest-value item, and nobody proposed it.** Five of six sections
+   hand-pin `color` on ~20 `<Link>`s to dodge the same trap. One recipe kills it site-wide.
+7. **Brand nouns keyed vs unkeyed contradiction.** "GitHub" is unkeyed (Hero) and keyed
+   (Contact) in the same PR series. Proposed rule: *if you'd write it identically in ja and
+   uk, it's data; if you'd translate it, it's copy.*
+8. **Anchor contract:** all five ids are missing today (one `id=` exists in all of `src/`,
+   on the wrong element under the wrong name). Adding ids has **zero visual effect** → put
+   them in shared, and the "Header first vs last" dilemma dissolves.
+
+---
+
+## Recommended order
+
+0. **`chore/redesign-shared`** — theme (keyframes, breakpoint/condition, `container.page`
+   1160px, `letterSpacings.kicker`, a small-end `fontSizes` scale below today's `sm: 1rem`
+   floor, radii, `buttonRecipe`/`headingRecipe`, **`linkRecipe`**, `globalCss` incl.
+   `scrollPaddingTop`), the MainSection decision, the 5 ids + `#work` retarget of
+   `HeroSection.tsx:43` (atomic — split it and Hero's CTA breaks silently in between), fonts
+   in `_app.tsx` + `preview.tsx` identically, `data.ts` short label.
+1–5. **Hero · About · Skills · Work · Contact** — fully parallel, no constraints left.
+6. **Header** — after ≥1 band, so its first baseline is a bar over redesigned content.
+7. **`chore/redesign-sweep`** — the only way "whoever lands last sweeps" becomes a real
+   assignment: `SocialLinksList`, `waggle`, `CurvedDownArrow`, `version-control.svg`, and
+   whichever icons are actually orphaned once Skills **and** Work have landed.
+
+---
+
+## Open corrections to fold in
+
+- **Baseline commit mismatch.** Every spec anchors to build 77 @ `c46544d`; HEAD is
+  `ca360ac`. Re-verify before trusting any "expect a diff" claim — a baseline attributed to
+  the wrong commit is the same failure class as the Dependabot count.
+- **Container queries work** (verified): named + tokens resolve inside the at-rule.
+- **v3 registers 34 keyframes**; `drawrail`/`nodepop`/`fadeup` don't collide.
+- **Untrusted-data check:** all 7 agents independently reported the design files contain
+  nothing resembling instructions; treated as data throughout. Only project
+  `3888fdd5-74ed-4b01-9f59-d3c985e1ddde` was opened.

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,5 @@
+{
+  "onlyChanged": true,
+  "projectId": "Project:62a2a5ff144ec0d564063746",
+  "zip": true
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "theme:watch": "chakra typegen src/lib/theme.ts --watch",
     "prepare": "husky install",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build --stats-json",
     "test-storybook": "vitest run --project=storybook"
   },
   "dependencies": {

--- a/src/components/AboutMeSection.stories.tsx
+++ b/src/components/AboutMeSection.stories.tsx
@@ -11,7 +11,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+// Guards the anchor contract — see HeroSection.stories.tsx for why this is the
+// only thing checking it.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector("#about"),
+      "AboutMeSection must keep id='about' — the header nav targets #about.",
+    ).not.toBeNull();
+  },
+};
 
 // CssCheck (the single one for the whole project): a canary proving the Chakra theme
 // actually loaded in the shared preview. AboutMeSection's MainSection renders as <section>

--- a/src/components/AboutMeSection.tsx
+++ b/src/components/AboutMeSection.tsx
@@ -29,8 +29,27 @@ export const AboutMeSection = () => {
     },
   };
   return (
+    // TRANSITIONAL: see the same pin in ReachOutSection. This band is the other
+    // legacy primary.base (#297b91) slab, so body's new fg (#eaf3f2) would render
+    // at 4.29:1 here — under AA. White is 4.84:1 and is what shipped before.
+    //
+    // VERIFIED, and worth knowing: axe does NOT flag this section, while it DOES
+    // flag the identical 4.29:1 in ReachOutSection. Tested directly — dropping
+    // this pin leaves the a11y run green. The only structural difference is the
+    // skewed ::before below (position:relative + zIndex:-1 + an inset boxShadow),
+    // which leaves the effective background undeterminable, so axe declines to
+    // measure rather than reporting a violation.
+    //
+    // So the contrast here was never checked by anything. A green a11y run on
+    // this section is the ABSENCE OF A MEASUREMENT, not the presence of a pass.
+    //
+    // Delete this pin in the About section PR, together with bg="primary.base"
+    // and the skew (the design replaces both with a flat bg.band, where #eaf3f2
+    // is 16.30:1 and axe can actually see it).
     <MainSection
+      id="about"
       bg="primary.base"
+      color="body"
       gap={{ base: 16, lg: 36 }}
       position="relative"
       {...skewBackgroundStyles}

--- a/src/components/HeroSection.stories.tsx
+++ b/src/components/HeroSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 
 import { HeroSection } from "./HeroSection";
 
@@ -10,4 +11,25 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+// Guards the anchor contract, which NOTHING else in this project checks: a dead
+// in-page anchor throws no error, logs nothing, fails no typecheck or build, and
+// axe does not verify that a fragment resolves. The header nav links to all five
+// section ids, so a section PR that rewrites this component and drops its id
+// would break navigation silently.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector("#top"),
+      "HeroSection must keep id='top' — the header brand link targets #top.",
+    ).not.toBeNull();
+
+    // The other half of an atomic pair: the id moved off ProjectsSection's
+    // <Heading id="projects-contributions"> onto its section as id="work", and
+    // this CTA is that id's only referrer. Split across two PRs, this href would
+    // dangle in between.
+    await expect(
+      canvasElement.querySelector('a[href="#work"]'),
+      "Hero's CTA must target #work (renamed from #projects-contributions).",
+    ).not.toBeNull();
+  },
+};

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -16,7 +16,7 @@ import { SocialLinksList } from "./SocialLinksList";
 export const HeroSection = () => {
   const { t } = useTranslation();
   return (
-    <MainSection gap={20}>
+    <MainSection id="top" gap={20}>
       <Flex
         flexDir={{ base: "column", lg: "row" }}
         columnGap={8}
@@ -31,7 +31,11 @@ export const HeroSection = () => {
             <Heading as="h1" size="4xl">
               {t("hero-site-title")}
             </Heading>
-            <Text as="span" fontSize={["md", null, "lg"]}>
+            {/* Object syntax, not the array form this used to use. Array indices
+                map to the SORTED breakpoint list, so adding `nav` (640px) to the
+                theme silently moved index 2 from md (768px) to nav (640px) — the
+                lg size would have kicked in 128px early. Named keys cannot shift. */}
+            <Text as="span" fontSize={{ base: "md", md: "lg" }}>
               {t("hero-site-subtitle")}
             </Text>
           </VStack>
@@ -40,7 +44,7 @@ export const HeroSection = () => {
             <Text>{t("hero-desc-2")}</Text>
           </Box>
           <Button asChild>
-            <Link href="#projects-contributions">{t("hero-cta")}</Link>
+            <Link href="#work">{t("hero-cta")}</Link>
           </Button>
         </VStack>
         <Image

--- a/src/components/MainSection.tsx
+++ b/src/components/MainSection.tsx
@@ -1,5 +1,29 @@
 import { VStack, StackProps } from "@chakra-ui/react";
 
+/**
+ * LEGACY SHELL — frozen. Do not grow this into the redesign's band.
+ *
+ * The redesign's decision (PR2 shared), recorded here because four section specs
+ * proposed four incompatible futures for this component:
+ *
+ * 1. MainSection stays exactly as-is and is NOT extended. It serves only the
+ *    un-redesigned sections. Each section PR drops it as that section lands; the
+ *    redesign sweep PR deletes the file once the last consumer is gone.
+ * 2. Redesigned sections render their own full-bleed `<section>` (their own
+ *    background, since the design alternates canvas/band) wrapping an inner shell
+ *    at `maxW="container.page"` (1160px) with `px="clamp(20px, 5vw, 32px)"`.
+ * 3. There is deliberately NO shared `Band` component yet. The bands' padding is
+ *    NOT uniform — hero's bottom is clamp(72px,13vw,132px) against a
+ *    clamp(64px,12vw,120px) top, contact's card is clamp(44px,9vw,72px)
+ *    clamp(24px,6vw,56px), and header/footer share neither. Only maxW (already
+ *    `sizes.container.page`) and the horizontal clamp are common — two values, not
+ *    an abstraction. Extract Band when two sections actually agree on an API.
+ *
+ * Why not just restructure this into an outer/inner pair: AboutMeSection passes a
+ * skewed `_before` whose `bg: "inherit"` reads from the SAME element that carries
+ * `bg="primary.base"`. Split them and the pseudo-element inherits transparent, the
+ * teal bleed silently vanishes, and it typechecks clean the whole way.
+ */
 export const MainSection = (props: StackProps) => (
   <VStack
     as="section"

--- a/src/components/ProjectsSection/ProjectsSection.stories.tsx
+++ b/src/components/ProjectsSection/ProjectsSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 
 import { ProjectsSection } from "./index";
 
@@ -10,4 +11,20 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+// Guards the anchor contract — see HeroSection.stories.tsx for why this is the
+// only thing checking it. This id carries the highest risk of the five: it was
+// RENAMED here (off the <Heading id="projects-contributions"> onto the section as
+// id="work"), and its only referrer lives in a different file (HeroSection's CTA).
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector("#work"),
+      "ProjectsSection must keep id='work' — the header nav and hero CTA target #work.",
+    ).not.toBeNull();
+
+    await expect(
+      canvasElement.querySelector("#projects-contributions"),
+      "The old id must not come back — it would duplicate the anchor target.",
+    ).toBeNull();
+  },
+};

--- a/src/components/ProjectsSection/index.tsx
+++ b/src/components/ProjectsSection/index.tsx
@@ -25,8 +25,8 @@ const triggerStyles = {
 export const ProjectsSection = () => {
   const { t } = useTranslation();
   return (
-    <VStack gap={{ base: "16", lg: "24" }} w="full">
-      <Heading id="projects-contributions">{t("projects-title")}</Heading>
+    <VStack id="work" gap={{ base: "16", lg: "24" }} w="full">
+      <Heading>{t("projects-title")}</Heading>
       <Tabs.Root
         defaultValue="open-source"
         variant="enclosed"

--- a/src/components/ReachOutSection.stories.tsx
+++ b/src/components/ReachOutSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 
 import { ReachOutSection } from "./ReachOutSection";
 
@@ -10,4 +11,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+// Guards the anchor contract — see HeroSection.stories.tsx for why this is the
+// only thing checking it. NOTE this component becomes ContactSection in its own
+// section PR; the id must survive the rename.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector("#contact"),
+      "ReachOutSection must keep id='contact' — the header nav and hero CTA target #contact.",
+    ).not.toBeNull();
+  },
+};

--- a/src/components/ReachOutSection.tsx
+++ b/src/components/ReachOutSection.tsx
@@ -6,7 +6,15 @@ import { useTranslation } from "next-i18next";
 export const ReachOutSection = () => {
   const { t } = useTranslation();
   return (
-    <MainSection bg="primary.base" gap="16" px="4">
+    // TRANSITIONAL: pins the text back to white. globalCss now defaults body to
+    // fg (#eaf3f2), but this section still paints the LEGACY teal slab
+    // (primary.base #297b91), and #eaf3f2 on it is 4.29:1 — under AA. White is
+    // 4.84:1, which is what shipped before and what this preserves exactly.
+    //
+    // A text colour and its backdrop are a PAIR. The redesign changes both: this
+    // band becomes bg.canvas, where #eaf3f2 is 16.30:1. Delete this pin in the
+    // Contact section PR, together with bg="primary.base".
+    <MainSection id="contact" bg="primary.base" color="body" gap="16" px="4">
       <VStack gap="text.base" maxW="xl">
         <Heading>{t("reach-out-title")}</Heading>
         <Text>{t("reach-out-desc")}</Text>

--- a/src/components/SkillsSection.stories.tsx
+++ b/src/components/SkillsSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
 
 import { SkillsSection } from "./SkillsSection";
 
@@ -10,4 +11,13 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+// Guards the anchor contract — see HeroSection.stories.tsx for why this is the
+// only thing checking it.
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector("#skills"),
+      "SkillsSection must keep id='skills' — the header nav targets #skills.",
+    ).not.toBeNull();
+  },
+};

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -102,7 +102,7 @@ export const SkillsSection = () => {
   ];
 
   return (
-    <VStack gap={{ base: "16", md: "20" }}>
+    <VStack id="skills" gap={{ base: "16", md: "20" }}>
       <Heading as="h3" size="2xl">
         {t("skills-title")}
       </Heading>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -9,7 +9,18 @@ import { IconType } from "react-icons/lib";
 type SocialMediaLinkType = {
   href: string;
   icon: IconType;
+  /** The full handle. Rendered by the current SocialLinksList. */
   label: string;
+  /**
+   * The redesign's hero pill text — deliberately terser than `label`.
+   *
+   * NOT routed through i18n, matching the existing precedent for this file.
+   * Three of the four are brand/handle strings that must never be translated.
+   * The fourth, "Email", IS an ordinary English word and is the one member that
+   * arguably should be a t() key on a 13-locale site. Left plain so the choice is
+   * visible rather than buried: the Hero/Contact section PRs own the call.
+   */
+  shortLabel: string;
   platform: "Github" | "Twitter" | "Linkedin" | "Email";
 };
 
@@ -18,24 +29,28 @@ export const socialMediaLinks: SocialMediaLinkType[] = [
     href: "https://twitter.com/t_pfledderer/",
     icon: FaTwitterSquare,
     label: "@t_pfledderer",
+    shortLabel: "@t_pfledderer",
     platform: "Twitter",
   },
   {
     href: "https://github.com/tylerapfledderer",
     icon: FaGithub,
     label: "@tylerapfledderer",
+    shortLabel: "GitHub",
     platform: "Github",
   },
   {
     href: "https://linkedin.com/in/tyler-pfledderer",
     icon: FaLinkedinIn,
     label: "in/tyler-pfledderer",
+    shortLabel: "LinkedIn",
     platform: "Linkedin",
   },
   {
     href: "mailto:tyler.pfledderer@gmail.com",
     icon: FaEnvelope,
     label: "tyler.pfledderer@gmail.com",
+    shortLabel: "Email",
     platform: "Email",
   },
 ];

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -43,48 +43,97 @@ const headingRecipe = defineRecipe({
   },
 });
 
-// Button: v2 baked the "lg" size into baseStyle; in v3 that's defaultVariants.
-// fontSize lives in the size variant (not base) because Chakra's default
-// size.lg carries textStyle:"md", and variants are applied after base.
+// Link: THE highest-value recipe here, and the only mechanism that works.
+//
+// v3's link recipe is defaultVariants:{variant:"plain"}, and `plain` sets
+// color:"colorPalette.fg" → --chakra-colors-gray-fg → _light → gray.800
+// (#27272a). With no colour mode the _light branch always wins, so an UNSTYLED
+// <Link> renders near-black on this dark canvas — measured 1.24:1 in the header
+// and 1.09:1 in About. It typechecks clean.
+//
+// The intuitive central fix does NOT work: porting the design's global
+// `a { color:#56c4da }` into globalCss puts it in the `base` layer, and layer
+// order is reset(0) base(1) tokens(2) recipes(3) — the link recipe would
+// silently win. Only a recipe beats a recipe.
+//
+// Overriding here REPLACES plain.color while v3's base (display/gap/
+// focusVisibleRing) and the `underline` variant still merge through.
+const linkRecipe = defineRecipe({
+  variants: {
+    variant: {
+      plain: {
+        color: "accent.emphasis",
+        // The design sets text-decoration:none globally. v3's plain._hover adds
+        // an underline; this deep-MERGES, so "none" is required to suppress it.
+        // Its textUnderlineOffset/textDecorationColor siblings survive and are
+        // inert once there is no underline to draw.
+        textDecoration: "none",
+        transition: "color .18s ease",
+        _hover: { color: "accent.bright", textDecoration: "none" },
+      },
+    },
+  },
+});
+
+// Button: the design's three weights (DesignSystem §04, which now carries the
+// Portfolio's real values rather than the stale specimen board it used to).
+//
+// Names are deliberately NOT changed: `solid` was already the amber primary and
+// `outline` already existed, so every current call site keeps working and simply
+// picks up the redesign values. `solidTeal` is the one addition.
+//
+// Two design shapes are intentionally absent because each has a single consumer:
+// the 999px nav pill (Header) and the 11px/14.5px card button (Work). Their
+// section PRs own them; a shared recipe should have >=2 consumers.
 const buttonRecipe = defineRecipe({
   base: {
-    // v2 rendered semibold; v3's default button recipe sets medium (500).
-    fontWeight: "semibold",
-    // v3's base adds a 1px transparent border that v2 had no equivalent for, which
-    // makes every button 2px wider. The outline variant re-asserts its own 2px.
+    // The design's buttons are anchors laid out as inline-flex with a real touch
+    // target, not h-sized boxes. minH 44px is the design's own a11y floor.
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minH: "44px",
+    px: "30px",
+    // 13px. v3's base uses the l2 semantic radius (4px).
+    borderRadius: "0.8125rem",
+    // v3's base adds a 1px transparent border, which would make every button 2px
+    // wider than the design. outlineTeal re-asserts its own.
     borderWidth: "0",
-    // v2 resolved to 6px; v3's base uses the l2 semantic radius, which is 4px.
-    borderRadius: "md",
+    whiteSpace: "nowrap",
   },
   variants: {
     variant: {
       solid: {
-        color: "background",
-        bg: "secondary.base",
-        _hover: { bg: "secondary.light" },
-        _active: { bg: "secondary.dark" },
+        bg: "warm.solid",
+        color: "warm.contrast",
+        fontWeight: "700",
+        _hover: { bg: "warm.emphasis" },
+      },
+      solidTeal: {
+        bg: "accent.solid",
+        color: "accent.contrast",
+        fontWeight: "700",
+        _hover: { bg: "accent.emphasis" },
       },
       outline: {
-        borderWidth: "2px",
-        borderColor: "body",
-        // v2 inherited white from body; v3's default outline variant would
-        // otherwise supply colorPalette.fg (near-black on our dark surface).
-        color: "body",
-        _hover: { bg: "body", color: "background" },
-        _active: { opacity: 0.6 },
+        borderWidth: "1px",
+        borderColor: "rgba(86,196,218,.28)",
+        // #dbeceb. One of NINE greys the design uses and does not name — the DS
+        // documents only Ink (#eaf3f2) and Muted. Raw until that ramp is settled.
+        color: "#dbeceb",
+        fontWeight: "600",
+        _hover: {
+          borderColor: "accent.emphasis",
+          bg: "rgba(86,196,218,.08)",
+        },
       },
     },
     size: {
-      // v2's baseStyle spread its own sizes.lg ({h:12, minW:12, px:6}) then forced
-      // fontSize:"sm". v3's default lg is smaller (h:11, px:5) and composes
-      // textStyle:"md", which would override fontSize and push lineHeight to 1.5rem.
-      // Pin the v2 dimensions rather than inherit v3's, so the buttons keep their size.
+      // 16.5px. textStyle:"none" neutralises the textStyle v3's default size
+      // composes in, which would otherwise clobber fontSize and lineHeight.
       lg: {
         textStyle: "none",
-        fontSize: "sm",
-        h: "12",
-        minW: "12",
-        px: "6",
+        fontSize: "1.03125rem",
       },
     },
   },
@@ -95,20 +144,77 @@ const buttonRecipe = defineRecipe({
 });
 
 const config = defineConfig({
+  // TOP-LEVEL, not under `theme` — nested there it typechecks and silently
+  // vanishes. Adding one condition MERGES with v3's defaults (_hover, _dark, …);
+  // it does not replace them. Author it bare, consume it prefixed: _skillsWide.
+  //
+  // This only NAMES the query. The element must still carry
+  // containerType:"inline-size" + containerName:"skills" or it never fires.
+  // Skills swaps its graphic on CONTENT width, not viewport, because the rail
+  // needs 760px of its own box — a viewport query would lie about that.
+  conditions: {
+    skillsWide: "@container skills (min-width: 820px)",
+  },
   globalCss: {
-    // The background lives on html, NOT body. v3's default globalCss sets
-    // html{bg:"bg"}, which stops CSS background-propagation — so unlike v2, body
-    // paints its own background box. That box would cover AboutMe's skewed
-    // ::before (zIndex:-1), erasing the teal bleed above and below the section.
-    // Painting html and leaving body bare reproduces v2's propagated-canvas
-    // result, and still keeps overscroll areas dark.
+    // The background lives on html, NOT body. TWO independent reasons — the
+    // second outlives the first, so do not "simplify" this rule away:
+    //
+    // 1. v3's default globalCss sets html{bg:"bg"}, which stops CSS
+    //    background-propagation — so unlike v2, body paints its own background
+    //    box. That box would cover AboutMe's skewed ::before (zIndex:-1),
+    //    erasing the teal bleed above and below the section. STILL LIVE: About
+    //    is un-redesigned as of this PR; the design drops the skew, so this
+    //    reason expires when the About section PR lands.
+    // 2. `colors.bg` is v3's semantic token, and with no colour mode it resolves
+    //    its _light branch — WHITE. Deleting this rule does not fall back to
+    //    "nothing"; it falls back to a white canvas. (We also pin bg.DEFAULT
+    //    above, so both ends agree.) Moving the paint to body would need
+    //    html:{bg:"transparent"} as well, to restore propagation.
     html: {
-      bg: "background",
+      bg: "bg.canvas",
+      // v3's default html rule is lineHeight:"1.5" — the token NAME, which this
+      // theme hijacks to a 3.56rem LENGTH. So <html> silently carries a 56.96px
+      // line box, masked only by body's rule below. Pin it explicitly.
+      lineHeight: "1.5625rem",
+      scrollBehavior: "smooth",
+      // Nested INSIDE the selector, not wrapped around it: globalCss types an
+      // at-rule's value as an element-level style object, so a selector map in
+      // there does not compile.
+      "@media (prefers-reduced-motion: reduce)": {
+        scrollBehavior: "auto",
+      },
     },
     body: {
-      color: "body",
-      fontSize: "md",
-      lineHeight: "1",
+      color: "fg",
+      // The design's Body role. Fluid 16→18px, saturating at a 450px viewport.
+      // rem so it honours the reader's browser font-size.
+      fontSize: "clamp(1rem, 4vw, 1.125rem)",
+      // A FIXED length, not a ratio: this is what holds the 25px baseline while
+      // fontSize ramps. Ratio 1.5625 at 16px, 1.389 at 18px.
+      lineHeight: "1.5625rem",
+    },
+    // v3 owns this exact key (colorPalette.emphasized/80 → gray, since html sets
+    // colorPalette:"gray"). Authoring "*::selection" REPLACES it; authoring
+    // "::selection" would emit a SECOND rule at equal specificity and let
+    // emission order decide. Use v3's key.
+    "*::selection": {
+      bg: "rgba(86,196,218,.28)",
+    },
+    // The design ships neither a reduced-motion guard nor a focus treatment,
+    // while running smooth scroll + 21 animated instances. This PR introduces
+    // both the scroll behaviour and the three keyframes, so it owns the guard.
+    //
+    // duration:0.01ms, NOT `animation:none`. The animations here resolve to
+    // their FINAL state — drawrail ends at stroke-dashoffset:0, i.e. the rail
+    // DRAWN. `animation:none` would instead leave each consumer's inline start
+    // state (dashoffset:600 / :1) and hide the rail permanently.
+    "*, *::before, *::after": {
+      "@media (prefers-reduced-motion: reduce)": {
+        animationDuration: "0.01ms !important",
+        animationIterationCount: "1 !important",
+        transitionDuration: "0.01ms !important",
+        scrollBehavior: "auto !important",
+      },
     },
     // v2's source was `p: { _notLast: {...} }`, i.e. :not(:last-of-type). Spelled out
     // flat because globalCss does not process the _notLast condition when nested under
@@ -116,10 +222,22 @@ const config = defineConfig({
     // :last-child: the latter also matches a <p> followed by a non-<p> sibling (the
     // hero's scroll notice above its arrow icon), adding margin v2 never applied.
     "p:not(:last-of-type)": {
-      mb: "text.base",
+      mb: "line.1",
     },
   },
   theme: {
+    // The design swaps the header nav at 640px. v3's `sm` is 480px, and the nav
+    // measurably overflows it (by 3px in English; de/fr/pl need ~600px), so `sm`
+    // is not a substitute on a 13-locale site.
+    //
+    // This MERGES with v3's sm/md/lg/xl/2xl (verified) and sorts by value, so
+    // `nav` lands between sm(480) and md(768) — there is no cascade inversion.
+    // But it DOES shift ARRAY responsive syntax, whose index 2 moves md → nav.
+    // The one at-risk call site (HeroSection.tsx fontSize) is converted to object
+    // syntax in this same PR; SocialLinksList's [base, sm] pair is unaffected.
+    breakpoints: {
+      nav: "640px",
+    },
     // Keyframes referenced by name via animationName (v3 dropped the `keyframes`
     // export). Used by SocialLinksList's icon hover animation.
     keyframes: {
@@ -128,6 +246,107 @@ const config = defineConfig({
         "40%": { transform: "scale(1.9) rotate(10deg)" },
         "60%": { transform: "scale(1.6) rotate(-10deg)" },
         "100%": { transform: "scale(1.4)" },
+      },
+      // Redesign motif. Verbatim from the design; these MERGE with v3's 34
+      // defaults (verified) and collide with none of them.
+      //
+      // drawrail is deliberately `to`-only: each consumer supplies its own start
+      // state inline (Hero's rail uses stroke-dasharray/offset:600; Skills' uses
+      // pathLength=1 + dasharray/offset:1). Moving the start state into the
+      // keyframe would make it un-shareable between the two.
+      drawrail: {
+        to: { strokeDashoffset: "0" },
+      },
+      nodepop: {
+        "0%": { transform: "scale(0)", opacity: "0" },
+        "70%": { transform: "scale(1.25)" },
+        "100%": { transform: "scale(1)", opacity: "1" },
+      },
+      fadeup: {
+        from: { opacity: "0", transform: "translateY(16px)" },
+        to: { opacity: "1", transform: "translateY(0)" },
+      },
+    },
+    // The design's type scale (DesignSystem.dc.html §02), as roles rather than
+    // sizes — each row bundles size + line-height + weight + tracking + family,
+    // which is exactly what a v3 textStyle is. Adding these MERGES with v3's
+    // defaults (verified); it does not replace them.
+    //
+    // px in the design → rem here, so the scale honours the reader's browser
+    // font-size. The `vw` term is intentionally left as-is (it is what makes the
+    // ramp fluid); only the clamp endpoints scale with the root.
+    //
+    // Line-heights are FIXED LENGTHS, not ratios — that is what holds the design's
+    // 25px baseline while the font-size ramps. A unitless ratio cannot: the box
+    // would drift with the size. 1.5625rem = 25px = one line.
+    textStyles: {
+      display: {
+        value: {
+          fontFamily: "heading",
+          fontSize: "clamp(2.875rem, 11vw, 5.375rem)",
+          lineHeight: "clamp(3.125rem, 12.8vw, 6.25rem)",
+          fontWeight: "700",
+          letterSpacing: "-0.015em",
+        },
+      },
+      h1: {
+        value: {
+          fontFamily: "heading",
+          fontSize: "clamp(2.375rem, 5.5vw, 4rem)",
+          lineHeight: "clamp(3.125rem, 6.44vw, 4.6875rem)",
+          fontWeight: "700",
+        },
+      },
+      h2: {
+        value: {
+          fontFamily: "heading",
+          fontSize: "clamp(1.9375rem, 7vw, 3.4375rem)",
+          lineHeight: "clamp(2.34375rem, 7.95vw, 3.90625rem)",
+          fontWeight: "700",
+        },
+      },
+      h3: {
+        value: {
+          fontFamily: "heading",
+          fontSize: "clamp(1.375rem, 5vw, 1.75rem)",
+          lineHeight: "clamp(1.5625rem, 6.7vw, 2.34375rem)",
+          fontWeight: "600",
+        },
+      },
+      lead: {
+        value: {
+          fontFamily: "body",
+          fontSize: "clamp(1.125rem, 4.5vw, 1.40625rem)",
+          lineHeight: "clamp(1.5625rem, 6.25vw, 1.953125rem)",
+          fontWeight: "400",
+        },
+      },
+      body: {
+        value: {
+          fontFamily: "body",
+          fontSize: "clamp(1rem, 4vw, 1.125rem)",
+          lineHeight: "1.5625rem",
+          fontWeight: "400",
+        },
+      },
+      small: {
+        value: {
+          fontFamily: "body",
+          fontSize: "0.875rem",
+          lineHeight: "1.5625rem",
+          fontWeight: "500",
+        },
+      },
+      // Kickers / tags / sha labels. The design pairs 13px with .24em uppercase.
+      mono: {
+        value: {
+          fontFamily: "mono",
+          fontSize: "0.8125rem",
+          lineHeight: "1.5625rem",
+          fontWeight: "500",
+          letterSpacing: "0.24em",
+          textTransform: "uppercase",
+        },
       },
     },
     tokens: {
@@ -160,13 +379,22 @@ const config = defineConfig({
           solid: { value: "#33a6c0" },
           emphasis: { value: "#56c4da" },
           muted: { value: "#7fb6c2" },
+          // Ink for text sitting ON accent.solid (the teal button / selected tab).
+          contrast: { value: "#04191d" },
+          // Link hover only. The design's global `a:hover`.
+          bright: { value: "#8bd8e8" },
         },
         warm: {
           solid: { value: "#f2b544" },
+          // Amber button hover.
+          emphasis: { value: "#ffca63" },
+          // Ink for text sitting ON warm.solid.
+          contrast: { value: "#231701" },
         },
-        fg: {
-          default: { value: "#eaf3f2" },
-        },
+        // NOTE: `fg` is NOT here. v3's key is uppercase DEFAULT, so a plain
+        // `fg: { default }` registers `colors.fg.default` — a *different*,
+        // unreferenced token — and leaves `colors.fg` on v3's black. See
+        // semanticTokens below.
       },
       // v3 dropped the container.* sizes scale; re-added with the v2 values so
       // the maxW="container.*" call sites keep their caps.
@@ -176,6 +404,9 @@ const config = defineConfig({
           md: { value: "768px" },
           lg: { value: "1024px" },
           xl: { value: "1280px" },
+          // The redesign's band shell. All seven design bands (header, hero,
+          // about, skills, work, contact, footer) cap at this width.
+          page: { value: "1160px" },
         },
       },
       // Self-hosted font families via CSS vars (see _app.tsx / @fontsource).
@@ -200,8 +431,26 @@ const config = defineConfig({
         "2": { value: "4.75rem" },
         "3": { value: "7.125rem" },
       },
-      // Custom typographic spacing scale; referenced as gap="text.base" etc.
       spacing: {
+        // The redesign's rhythm unit: a 25px baseline = the Body line box.
+        // Every vertical measure resolves to a whole (or half) multiple, so text
+        // across columns locks to one grid. Referenced as gap="line.1" etc.
+        //
+        // NOTE this is a BASELINE, not an 8px grid — 25px is not a multiple of 8.
+        // Headings are deliberately NOT locked to it: their font-size clamps ramp
+        // ~1.7x faster than Body's, so a fixed multiple would force sub-1.0
+        // line-heights on display type. Headings are optical; blocks are on-grid.
+        line: {
+          half: { value: "0.78125rem" }, // 12.5px · dense component gaps
+          "1": { value: "1.5625rem" }, //   25px · base unit / block gap
+          "2": { value: "3.125rem" }, //    50px · card padding
+          "3": { value: "4.6875rem" }, //   75px · sub-section spacing
+          "4": { value: "6.25rem" }, //    100px · section padding
+          "5": { value: "7.8125rem" }, //  125px · major separation
+        },
+        // DEPRECATED — the v2-era 19px grid (1-8 x 1.188rem). Superseded by
+        // `line.*` above. Still referenced by un-redesigned sections; the
+        // redesign sweep PR retires it once every section has migrated.
         text: {
           sm: { value: "1.188rem" },
           base: { value: "2.375rem" },
@@ -224,9 +473,20 @@ const config = defineConfig({
     // each takes a flat value, not a `.base` sub-key.
     semanticTokens: {
       colors: {
+        // DEFAULT registers the BARE name (`colors.fg`), which is what v3's own
+        // globalCss html rule and ~15 default recipes reference. Lowercase
+        // `default` does NOT — that was the #22 bug: it minted colors.fg.default
+        // (referenced nowhere) while colors.fg stayed v3's _light black.
+        // Unlike `base`, DEFAULT does not collapse its siblings.
         fg: {
+          DEFAULT: { value: "#eaf3f2" },
           muted: { value: "#a9bab9" },
           subtle: { value: "#7a9ea0" },
+        },
+        // v3's `bg` is _light white. It backs v3's default html{bg:"bg"}, so
+        // deleting our html rule below would paint the canvas WHITE, not nothing.
+        bg: {
+          DEFAULT: { value: "#0b1617" },
         },
         border: {
           subtle: { value: "#56c4da24" },
@@ -236,6 +496,7 @@ const config = defineConfig({
     recipes: {
       heading: headingRecipe,
       button: buttonRecipe,
+      link: linkRecipe,
     },
   },
 });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,8 +4,20 @@ import { appWithTranslation } from "next-i18next";
 // Self-hosted fonts (bundled, no build-time Google Fonts fetch — keeps builds/deploys
 // reliable and offline-capable). Registers the "Titillium Web" / "Mulish" families used
 // by the theme via var(--font-tw) / var(--font-mulish).
+// Weights are added only where a rule actually USES them — the design's Google
+// Fonts link over-declares (it requests Titillium 400 and Mulish 500, which no
+// rule in either design file references). Keep this list IDENTICAL to the one in
+// .storybook/preview.tsx: without a matching @font-face, Chromatic's Linux
+// container silently falls back to a system font and the visual gate stops
+// testing what production renders.
+// 700 = display/h1/h2; 600 = h3 (textStyles.h3) and the nav panel links.
+import "@fontsource/titillium-web/600.css";
 import "@fontsource/titillium-web/700.css";
+// 400 = body; 600 = outline button / nav pill / tabs; 700 = the amber CTA.
+// 600 and 700 are consumed by buttonRecipe's variants.
 import "@fontsource/mulish/400.css";
+import "@fontsource/mulish/600.css";
+import "@fontsource/mulish/700.css";
 // JetBrains Mono via var(--font-mono). 400 = labels/tags/sha; 500 = kickers.
 // The design's font link also requests 600, but no mono element uses it.
 import "@fontsource/jetbrains-mono/400.css";


### PR DESCRIPTION
The shared foundation for the PR2 redesign fan-out. Per-section restyling lands in follow-up PRs cut from this branch; this PR is the substrate they all build on.

## What's here

- **Theme** (`theme.ts`): redesign token map, `textStyles` (8 roles, px→rem on a 25px baseline via fixed line-heights), `globalCss`, `linkRecipe` + `buttonRecipe`, keyframes, `prefers-reduced-motion` guard. Fixes #22's `DEFAULT` vs `default` trap — bare `fg`/`bg` now resolve at 1 condition (both were sitting on v3's light-mode default).
- **Fonts**: declared at `:root` in both `_app.tsx` and `.storybook/preview.tsx` (verified identical).
- **Anchor contract**: `#top #about #skills #work #contact`; `id="work"` moved onto the Work section atomically with Hero's CTA retarget. Per-section story assertions guard each id + the retarget — nothing else checks this.
- **Contrast**: legacy-teal sections (About, ReachOut) pinned to `color="body"` so text stays above AA. Scoped to die with `bg="primary.base"` in their section PRs.
- **Data**: `data.ts` gains `shortLabel` (Email flagged as its one translatable member).
- **Rules docs**: the `DEFAULT` trap, the "1 condition still dead" radii exception, and the axe/`::before` blind spot.
- **CI**: `chromatic.config.json`. **Meta**: `.claude/launch.json` (autoPort + `--ci`), `REDESIGN_SPECS.md`.

## Verification

- typecheck · lint · production build — green
- **6/6 story tests** (play + CssCheck + axe) — green
- Theme values browser-verified (not config-time only): `fg`/`bg`, html bg + 25px line-height, fluid body 16→18px, Button values

## Notes

- **`ProjectItemCard` is still unbaselined** in Chromatic (lazyMounted) — the Work section PR must close that gap.
- `linkRecipe` is config-verified only; no bare `<Link>` renders today. First section PR that renders one must confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)