### PR TITLE
test(work): baseline ProjectItemCard + OpenSourceItemCard stories

### DIFF
--- a/src/components/ProjectsSection/OpenSourceItemCard.stories.tsx
+++ b/src/components/ProjectsSection/OpenSourceItemCard.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import { OpenSourceItemCard } from "./OpenSourceItemCard";
+import { openSourceData } from "./utils";
+
+// Like ProjectItemCard, this card only ever rendered behind the lazyMounted
+// Open Source tab, so no story mounted it. This baselines it before the redesign
+// restyle.
+const meta = {
+  component: OpenSourceItemCard,
+  tags: ["ai-generated"],
+} satisfies Meta<typeof OpenSourceItemCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: openSourceData[0],
+  play: async ({ canvas }) => {
+    // The card's own concern: both actions render as real <a> elements (the
+    // Button asChild + Link wiring), with translated labels resolved. Href
+    // values are utils.ts echoed back, so they aren't asserted.
+    await expect(
+      canvas.getByRole("link", { name: /contribution/i }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("link", { name: /project/i }),
+    ).toBeInTheDocument();
+  },
+};
+
+// The other real item (Ethereum.org): a second role + a two-paragraph body, so
+// the description.map() branch is exercised — the card renders one <p> per
+// description entry, which the single-paragraph default does not prove.
+export const EthereumOrg: Story = {
+  args: openSourceData[1],
+  play: async ({ canvas }) => {
+    const paragraphs = canvas.getAllByText(/./, { selector: "p" });
+    await expect(paragraphs.length).toBeGreaterThanOrEqual(
+      openSourceData[1].description.length,
+    );
+  },
+};

--- a/src/components/ProjectsSection/ProjectItemCard.stories.tsx
+++ b/src/components/ProjectsSection/ProjectItemCard.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import { ProjectItemCard } from "./ProjectItemCard";
+import { projectsData } from "./utils";
+
+// FIRST story to ever mount ProjectItemCard. Until now the card sat behind
+// ProjectsSection's lazyMounted/unmountOnExit Projects tab, so no story reached
+// it — axe never saw it, Chromatic never baselined it, and the next/image mock
+// was never exercised at render. This story closes that gap BEFORE the redesign
+// restyle, so Chromatic has a real baseline to diff the restyle against.
+const meta = {
+  component: ProjectItemCard,
+  tags: ["ai-generated"],
+} satisfies Meta<typeof ProjectItemCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// idx 0 → even index → the `row` (image-left) layout branch.
+export const Default: Story = {
+  args: { idx: 0, ...projectsData[0] },
+  play: async ({ canvas }) => {
+    // The card's own concern: both actions render as real <a> elements (the
+    // Button asChild + Link wiring — a flattened `as` would emit a <div> and
+    // silently drop link semantics), with their translated labels resolved.
+    // The href VALUES are just utils.ts echoed back, so they aren't asserted.
+    await expect(canvas.getByRole("link", { name: /github/i })).toBeInTheDocument();
+    await expect(canvas.getByRole("link", { name: /demo/i })).toBeInTheDocument();
+  },
+};
+
+// idx 1 → odd index → the `row-reverse` (image-right) layout branch. Guards the
+// index-parity branching in the card's border/radius logic.
+export const OddIndex: Story = {
+  args: { idx: 1, ...projectsData[1] },
+};


### PR DESCRIPTION
First of two Work-section PRs (stories-first sequencing). This one adds no component/theme/data changes — it only **closes the card coverage gap and baselines the cards before the redesign restyle** (PR-B), so Chromatic can produce a real visual diff of the restyle instead of the cards arriving as brand-new stories with nothing to compare.

## What's here

- `ProjectItemCard.stories.tsx` — `Default` (link-wiring presence) + `OddIndex` (the index-parity `row`/`row-reverse` layout branch).
- `OpenSourceItemCard.stories.tsx` — `Default` + `EthereumOrg` (the `description.map()` multi-paragraph branch).

Both cards previously rendered only behind `ProjectsSection`'s `lazyMount`/`unmountOnExit` Work tabs, so **no story ever mounted them** — axe never saw them, Chromatic never baselined them, and the `next/image` mock was never exercised at render (see `.claude/rules/components.md`, "KNOWN OPEN GAP").

## Design decisions

- **Behavior-only assertions**, per Storybook's own testing split: play functions cover semantics/interaction; visual correctness is Chromatic's job. No `getComputedStyle` checks. `href` values aren't asserted (they'd just re-test `utils.ts`).
- Real data pulled from `utils.ts` so `t()` resolves via the global i18n decorator (all three namespaces loaded).

## Verification

- typecheck · lint — green
- **11/11 story tests** pass (play + axe), incl. the 4 new card stories — **first time axe checks these cards**, no violations.
- **Expect first-ever Chromatic baselines** for both cards (per `components.md`, they arrive as brand-new stories — needs human eyes on the first result).

## Next

PR-B (cut after this merges): the Work-section restyle + Option B data migration + theme token, diffed against this PR's baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)