### PR TITLE
test(storybook): snapshot every section at each Chakra breakpoint

### DIFF
--- a/.storybook/breakpoint-viewports.ts
+++ b/.storybook/breakpoint-viewports.ts
@@ -1,0 +1,74 @@
+import type { ViewportMap } from "storybook/viewport";
+
+import { system } from "../src/lib/theme";
+
+// Storybook viewports + Chromatic viewport modes, DERIVED from the Chakra
+// breakpoints rather than hand-copied. "Equal to the breakpoints" is then a
+// structural guarantee, not a thing to keep in sync: add or move a breakpoint in
+// src/lib/theme.ts and both the toolbar list and Chromatic's per-viewport
+// snapshots follow automatically. A hardcoded pixel list would silently drift the
+// first time the scale changed — the same dead-token failure class this repo
+// keeps getting bitten by (a value that typechecks clean and is quietly wrong).
+//
+// `system.breakpoints.values` is the MERGED, sorted set (Chakra's defaultConfig
+// sm/md/lg/xl/2xl + this theme's custom `nav`), so it is the real answer to "what
+// are the breakpoints", not just the one override theme.ts declares. It is public
+// typed API (BreakpointEntry[] = { name, min?, max? }), not an internal.
+//
+// The `base` (0-width) breakpoint has no entry in `.values` and is intentionally
+// omitted: it is the implicit below-`sm` default, not a boundary to snapshot at.
+// Every entry that IS here carries a `min`, and we snapshot at exactly that
+// min-width — the width at which the breakpoint first activates.
+
+// Chakra breakpoint minimums are rem (e.g. "30rem"); Chromatic modes accept only
+// whole numbers or "px"-suffixed strings. Convert to integer px. rem/em are ×16
+// (the browser root default; the site never overrides the root font-size), px
+// passes through. Anything else throws rather than emitting a silently wrong box.
+function toPx(min: string): number {
+  const value = parseFloat(min);
+  if (Number.isNaN(value)) {
+    throw new Error(`Unparseable breakpoint minimum: "${min}"`);
+  }
+  if (min.endsWith("rem") || min.endsWith("em")) return Math.round(value * 16);
+  if (min.endsWith("px")) return Math.round(value);
+  throw new Error(`Unsupported breakpoint unit in "${min}" — expected rem/em/px`);
+}
+
+// Toolbar-icon hint only (which glyph the viewport dropdown shows). Has no effect
+// on the captured pixels; purely cosmetic grouping in the Storybook UI.
+function viewportType(px: number): "mobile" | "tablet" | "desktop" {
+  if (px < 768) return "mobile";
+  if (px < 1024) return "tablet";
+  return "desktop";
+}
+
+const entries = system.breakpoints.values.filter(
+  (entry): entry is { name: string; min: string; max?: string | null } =>
+    typeof entry.min === "string",
+);
+
+// { sm: { name, styles, type }, nav: {...}, md, lg, xl, 2xl }
+export const breakpointViewports: ViewportMap = Object.fromEntries(
+  entries.map((entry) => {
+    const width = toPx(entry.min);
+    return [
+      entry.name,
+      {
+        name: `${entry.name} (${width}px)`,
+        // Height is a nominal tall box for the toolbar preview. Chromatic captures
+        // full story height by default (cropToViewport is off), so the width is
+        // the load-bearing value; height never crops a section.
+        styles: { width: `${width}px`, height: "900px" },
+        type: viewportType(width),
+      },
+    ];
+  }),
+);
+
+// One Chromatic mode per breakpoint, each referencing a viewport option by key.
+// Applied globally in preview.tsx so EVERY story (every section) is snapshotted
+// at EVERY breakpoint — the per-viewport-per-section coverage this adds.
+// { sm: { viewport: "sm" }, nav: { viewport: "nav" }, ... }
+export const breakpointModes = Object.fromEntries(
+  entries.map((entry) => [entry.name, { viewport: entry.name }]),
+) as Record<string, { viewport: string }>;

--- a/.storybook/breakpoint-viewports.ts
+++ b/.storybook/breakpoint-viewports.ts
@@ -15,10 +15,36 @@ import { system } from "../src/lib/theme";
 // are the breakpoints", not just the one override theme.ts declares. It is public
 // typed API (BreakpointEntry[] = { name, min?, max? }), not an internal.
 //
-// The `base` (0-width) breakpoint has no entry in `.values` and is intentionally
-// omitted: it is the implicit below-`sm` default, not a boundary to snapshot at.
-// Every entry that IS here carries a `min`, and we snapshot at exactly that
-// min-width — the width at which the breakpoint first activates.
+// Every entry that comes from `.values` carries a `min`, and we snapshot at
+// exactly that min-width — the width at which the breakpoint first activates.
+
+// Chakra's `base` breakpoint is the implicit below-`sm` default and has NO entry
+// in `.values` (its min-width is 0). Pin it to a concrete 375px — the canonical
+// modern-phone width (iPhone SE 2 / 8 / X-class) — so the true mobile layout gets
+// its own snapshot, which the 480px `sm` capture never reaches. Prepended to the
+// derived set; the sort below keeps it first since 375 < 480.
+const EXTRA_VIEWPORTS: { name: string; width: number }[] = [
+  { name: "base", width: 375 },
+];
+
+// A common real-world height for each viewport WIDTH — the height a device (or, at
+// desktop widths, the most common browser viewport) of that width actually has.
+// Height does NOT affect Chromatic captures: full story height is snapshotted
+// (cropToViewport is off), so this only sets the toolbar preview's aspect ratio.
+// Any width not listed (e.g. a future breakpoint) falls back to a 16:10 ratio.
+const COMMON_HEIGHT_BY_WIDTH: Record<number, number> = {
+  375: 667, //   iPhone SE (2nd gen) / 8 — canonical phone
+  480: 800, //   WVGA — common small Android
+  640: 960, //   DVGA
+  768: 1024, //  iPad, portrait
+  1024: 768, //  iPad, landscape (XGA)
+  1280: 800, //  WXGA laptop
+  1536: 864, //  the most common desktop viewport (scaled 1080p laptop)
+};
+
+function heightFor(width: number): number {
+  return COMMON_HEIGHT_BY_WIDTH[width] ?? Math.round((width * 10) / 16);
+}
 
 // Chakra breakpoint minimums are rem (e.g. "30rem"); Chromatic modes accept only
 // whole numbers or "px"-suffixed strings. Convert to integer px. rem/em are ×16
@@ -42,33 +68,33 @@ function viewportType(px: number): "mobile" | "tablet" | "desktop" {
   return "desktop";
 }
 
-const entries = system.breakpoints.values.filter(
-  (entry): entry is { name: string; min: string; max?: string | null } =>
-    typeof entry.min === "string",
-);
+// base (375) + the six named breakpoints, ascending by width.
+const viewports = [
+  ...EXTRA_VIEWPORTS,
+  ...system.breakpoints.values
+    .filter(
+      (entry): entry is { name: string; min: string; max?: string | null } =>
+        typeof entry.min === "string",
+    )
+    .map((entry) => ({ name: entry.name, width: toPx(entry.min) })),
+].sort((a, b) => a.width - b.width);
 
-// { sm: { name, styles, type }, nav: {...}, md, lg, xl, 2xl }
+// { base: {...}, sm: {...}, nav, md, lg, xl, 2xl }
 export const breakpointViewports: ViewportMap = Object.fromEntries(
-  entries.map((entry) => {
-    const width = toPx(entry.min);
-    return [
-      entry.name,
-      {
-        name: `${entry.name} (${width}px)`,
-        // Height is a nominal tall box for the toolbar preview. Chromatic captures
-        // full story height by default (cropToViewport is off), so the width is
-        // the load-bearing value; height never crops a section.
-        styles: { width: `${width}px`, height: "900px" },
-        type: viewportType(width),
-      },
-    ];
-  }),
+  viewports.map(({ name, width }) => [
+    name,
+    {
+      name: `${name} (${width}px)`,
+      styles: { width: `${width}px`, height: `${heightFor(width)}px` },
+      type: viewportType(width),
+    },
+  ]),
 );
 
-// One Chromatic mode per breakpoint, each referencing a viewport option by key.
+// One Chromatic mode per viewport, each referencing a viewport option by key.
 // Applied globally in preview.tsx so EVERY story (every section) is snapshotted
-// at EVERY breakpoint — the per-viewport-per-section coverage this adds.
-// { sm: { viewport: "sm" }, nav: { viewport: "nav" }, ... }
+// at EVERY viewport — the per-viewport-per-section coverage this adds.
+// { base: { viewport: "base" }, sm: { viewport: "sm" }, ... }
 export const breakpointModes = Object.fromEntries(
-  entries.map((entry) => [entry.name, { viewport: entry.name }]),
+  viewports.map(({ name }) => [name, { viewport: name }]),
 ) as Record<string, { viewport: string }>;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -54,21 +54,21 @@ const preview: Preview = {
       },
     },
 
-    // Viewport toolbar list = the Chakra breakpoints (sm/nav/md/lg/xl/2xl),
-    // derived in ./breakpoint-viewports.ts straight from system.breakpoints so it
-    // cannot drift from the theme. The default (no `initialGlobals.viewport`) stays
-    // Storybook's responsive 100% — a breakpoint is only forced when picked, or by
-    // Chromatic's modes below at capture time.
+    // Viewport toolbar list = base (375) + the Chakra breakpoints
+    // (sm/nav/md/lg/xl/2xl), derived in ./breakpoint-viewports.ts straight from
+    // system.breakpoints so it cannot drift from the theme. The default (no
+    // `initialGlobals.viewport`) stays Storybook's responsive 100% — a viewport is
+    // only forced when picked, or by Chromatic's modes below at capture time.
     viewport: {
       options: breakpointViewports,
     },
 
-    // Chromatic captures one snapshot per breakpoint for EVERY story. Set at the
+    // Chromatic captures one snapshot per viewport for EVERY story. Set at the
     // project level so all five section stories (and their a11y snapshots) inherit
     // the full per-viewport matrix without repeating it per file. `modes` replaces
     // the single default capture with one per entry — so each section is diffed at
-    // sm/nav/md/lg/xl/2xl instead of at one arbitrary width. A story that needs a
-    // narrower set can still override `chromatic.modes` locally.
+    // base/sm/nav/md/lg/xl/2xl instead of at one arbitrary width. A story that
+    // needs a narrower set can still override `chromatic.modes` locally.
     chromatic: {
       modes: breakpointModes,
     },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -42,6 +42,7 @@ import "@fontsource/jetbrains-mono/500.css";
 import "./fonts.css";
 
 import { Provider } from "../src/components/ui/provider";
+import { breakpointModes, breakpointViewports } from "./breakpoint-viewports";
 import i18n from "./i18n";
 
 const preview: Preview = {
@@ -51,6 +52,25 @@ const preview: Preview = {
        color: /(background|color)$/i,
        date: /Date$/i,
       },
+    },
+
+    // Viewport toolbar list = the Chakra breakpoints (sm/nav/md/lg/xl/2xl),
+    // derived in ./breakpoint-viewports.ts straight from system.breakpoints so it
+    // cannot drift from the theme. The default (no `initialGlobals.viewport`) stays
+    // Storybook's responsive 100% — a breakpoint is only forced when picked, or by
+    // Chromatic's modes below at capture time.
+    viewport: {
+      options: breakpointViewports,
+    },
+
+    // Chromatic captures one snapshot per breakpoint for EVERY story. Set at the
+    // project level so all five section stories (and their a11y snapshots) inherit
+    // the full per-viewport matrix without repeating it per file. `modes` replaces
+    // the single default capture with one per entry — so each section is diffed at
+    // sm/nav/md/lg/xl/2xl instead of at one arbitrary width. A story that needs a
+    // narrower set can still override `chromatic.modes` locally.
+    chromatic: {
+      modes: breakpointModes,
     },
 
     a11y: {


### PR DESCRIPTION
## What

Sets the Storybook viewport list equal to the Chakra breakpoints (plus a `base` mobile viewport), and has Chromatic capture a snapshot per viewport for every section.

## How

- **`.storybook/breakpoint-viewports.ts` (new)** — derives both the viewport options and the Chromatic viewport modes from `system.breakpoints.values` instead of hardcoding pixels. The merged, sorted set (Chakra's `sm`/`md`/`lg`/`xl`/`2xl` plus this theme's custom `nav`) is the single source, so "viewports == breakpoints" is a structural guarantee — add or move a breakpoint in `src/lib/theme.ts` and both the toolbar list and Chromatic's snapshot matrix follow automatically. Breakpoint minimums (rem) are converted to integer px, which is what the viewport styles and Chromatic modes both require.
  - **`base` viewport (375px):** Chakra's `base` breakpoint has no min-width (it's the implicit below-`sm` range), so it's added explicitly and pinned to 375px — the canonical modern-phone width — so the true mobile layout that the 480px `sm` snapshot never reaches gets its own capture. It sorts ahead of `sm`.
  - **Width-specific heights:** each viewport gets a common real-world height for its width (see table), rather than a flat value. A `16:10` ratio is the fallback for any future breakpoint width. Height only sets the toolbar preview's aspect ratio — Chromatic captures full story height (`cropToViewport` is off), so nothing is cropped.
- **`.storybook/preview.tsx`** — wires them in: `viewport.options` for the toolbar, and a project-level `chromatic.modes` so all five section stories (and their a11y snapshots) inherit the full per-viewport matrix. `modes` replaces Chromatic's single default capture with one per viewport.

## Resulting matrix

Each section story is now diffed at **7 viewports** — `base` plus the Chakra breakpoints:

| key    | width  | height | reference |
|--------|--------|--------|-----------|
| `base` | 375px  | 667px  | iPhone SE 2 / 8 |
| `sm`   | 480px  | 800px  | WVGA Android |
| `nav`  | 640px  | 960px  | DVGA |
| `md`   | 768px  | 1024px | iPad, portrait |
| `lg`   | 1024px | 768px  | iPad, landscape (XGA) |
| `xl`   | 1280px | 800px  | WXGA laptop |
| `2xl`  | 1536px | 864px  | most common desktop viewport |

The Storybook toolbar default stays the responsive 100% view; a viewport is only forced when picked in the toolbar, or by Chromatic at capture time. Individual stories can still override `chromatic.modes` locally for a narrower set.

## Verification

- `bun run typecheck` — clean
- `bun run build-storybook` — success
- `bun run test-storybook` — 7 passed (play + a11y + CssCheck across all 5 story files); confirms the new preview config loads without breaking story rendering
- Probed the derived output directly: the seven viewport widths/heights and mode keys match `system.breakpoints` (plus `base`) exactly

Note: every section will produce new per-viewport baselines in Chromatic on first run, which need human review (`exitZeroOnChanges: true`, so the job won't fail — Chromatic's own "UI Tests" check is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw1Uycs5TdsHUiATVfd6xk