### PR TITLE
feat(contact): redesign to Portfolio.dc.html gradient CTA card

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -16,8 +16,8 @@
   "projects-title": "Projects & Contributions",
   "projects-tab-open-source": "Open Source",
   "projects-tab-projects": "Projects",
-  "reach-out-title": "Reach Out!",
-  "reach-out-desc": "I am actively seeking employment opportunities and would be delighted to discuss further. Feel free to reach out to me below, and I'd be thrilled to contribute my skills to your team or assist in bringing your project to fruition!",
+  "reach-out-title": "Reach out!",
+  "reach-out-desc": "I'm actively seeking new opportunities and would be delighted to talk. Reach out below — I'd be thrilled to contribute to your team or help bring your project to fruition.",
   "footer-copyright": "Copyright {{date}} Tyler Pfledderer",
   "footer-desc": "This site is built with NextJS, TypeScript, and Chakra UI"
 }

--- a/src/components/ReachOutSection.stories.tsx
+++ b/src/components/ReachOutSection.stories.tsx
@@ -22,3 +22,27 @@ export const Default: Story = {
     ).not.toBeNull();
   },
 };
+
+// The redesign's three contact actions are the section's whole point, so pin
+// their hrefs: the mailto and the two social links are the actual contract a
+// visitor depends on. Queried by accessible name (link text).
+export const ContactActions: Story = {
+  play: async ({ canvas }) => {
+    const email = canvas.getByRole("link", {
+      name: "tyler.pfledderer@gmail.com",
+    });
+    await expect(email).toHaveAttribute(
+      "href",
+      "mailto:tyler.pfledderer@gmail.com",
+    );
+
+    await expect(canvas.getByRole("link", { name: "LinkedIn" })).toHaveAttribute(
+      "href",
+      "https://linkedin.com/in/tyler-pfledderer",
+    );
+    await expect(canvas.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/tylerapfledderer",
+    );
+  },
+};

--- a/src/components/ReachOutSection.tsx
+++ b/src/components/ReachOutSection.tsx
@@ -1,25 +1,110 @@
-import { Heading, Text, VStack } from "@chakra-ui/react";
-import { MainSection } from "./MainSection";
-import { SocialLinksList } from "./SocialLinksList";
+import { Button, Flex, Heading, Text, VStack, chakra } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
+
+// The design's contact CTA card (Portfolio.dc.html §contact). A teal gradient
+// panel on the dark canvas, with a radial glow overlay in the top-right. The
+// glow is a decorative ::before so it can sit behind the content without a
+// stacking-context fight; overflow:hidden clips it to the rounded card.
+const ContactCard = chakra("div", {
+  base: {
+    flex: "1",
+    display: "flex",
+    position: "relative",
+    overflow: "hidden",
+    rounded: "28px",
+    borderWidth: "1px",
+    borderColor: "rgba(86,196,218,.22)",
+    bgGradient: "to-br",
+    gradientFrom: "#12525e",
+    gradientTo: "#0e3038",
+    p: {
+      base: "clamp(44px, 9vw, 72px) clamp(24px, 6vw, 56px)",
+      md: "72px 56px",
+    },
+    _before: {
+      content: '""',
+      position: "absolute",
+      inset: "0",
+      pointerEvents: "none",
+      // The design anchors the glow at 80% 0% with a 520x320 falloff — a
+      // positioned radial that bgGradient's keyword shorthand can't express, so
+      // it's a raw backgroundImage.
+      bgImage:
+        "radial-gradient(520px 320px at 80% 0%, rgba(86,196,218,.22), transparent 60%)",
+    },
+  },
+});
+
+// White-outline social buttons — the design's contact-card treatment, distinct
+// from the teal `outline` recipe (borders are white-alpha here, on the teal
+// panel). Single consumer, so kept local per the theme.ts recipe-scoping note.
+const socialButtonStyles = {
+  variant: "outline",
+  borderColor: "rgba(255,255,255,.28)",
+  color: "#eefaf9",
+  fontWeight: "600",
+  _hover: { borderColor: "#fff", bg: "rgba(255,255,255,.08)" },
+} as const;
 
 export const ReachOutSection = () => {
   const { t } = useTranslation();
   return (
-    // TRANSITIONAL: pins the text back to white. globalCss now defaults body to
-    // fg (#eaf3f2), but this section still paints the LEGACY teal slab
-    // (primary.base #297b91), and #eaf3f2 on it is 4.29:1 — under AA. White is
-    // 4.84:1, which is what shipped before and what this preserves exactly.
-    //
-    // A text colour and its backdrop are a PAIR. The redesign changes both: this
-    // band becomes bg.canvas, where #eaf3f2 is 16.30:1. Delete this pin in the
-    // Contact section PR, together with bg="primary.base".
-    <MainSection id="contact" bg="primary.base" color="body" gap="16" px="4">
-      <VStack gap="text.base" maxW="xl">
-        <Heading>{t("reach-out-title")}</Heading>
-        <Text>{t("reach-out-desc")}</Text>
-      </VStack>
-      <SocialLinksList />
-    </MainSection>
+    // Full-bleed dark band. The legacy primary.base slab + its 4.29:1 color="body"
+    // pin are gone: the canvas is bg.canvas (#0b1617) where fg (#eaf3f2) is
+    // 16.30:1, and the teal now lives inside the gradient card below.
+    <Flex as="section" id="contact" w="full" bg="bg.canvas" textAlign="start">
+      <Flex
+        w="full"
+        maxW="container.page"
+        mx="auto"
+        px="clamp(20px, 5vw, 32px)"
+        py="clamp(64px, 12vw, 120px)"
+      >
+        <ContactCard>
+          <VStack position="relative" flex="1" align="center" gap="9">
+            <VStack align="center" gap="4">
+              <Heading textStyle="h2" color="#eefaf9" textAlign="center">
+                {t("reach-out-title")}
+              </Heading>
+              <Text
+                textStyle="lead"
+                color="#cfe4e3"
+                maxW="52ch"
+                textAlign="center"
+              >
+                {t("reach-out-desc")}
+              </Text>
+            </VStack>
+            <Flex wrap="wrap" gap="3" justify="center" align="center">
+              <Button asChild variant="solid">
+                <a href="mailto:tyler.pfledderer@gmail.com">
+                  tyler.pfledderer@gmail.com
+                </a>
+              </Button>
+              <Flex gap="3" flex="none">
+                <Button asChild {...socialButtonStyles}>
+                  <a
+                    href="https://linkedin.com/in/tyler-pfledderer"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    LinkedIn
+                  </a>
+                </Button>
+                <Button asChild {...socialButtonStyles}>
+                  <a
+                    href="https://github.com/tylerapfledderer"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    GitHub
+                  </a>
+                </Button>
+              </Flex>
+            </Flex>
+          </VStack>
+        </ContactCard>
+      </Flex>
+    </Flex>
   );
 };


### PR DESCRIPTION
Redesigns the **Contact** section (ReachOutSection) to the `Portfolio.dc.html` layout — the next section in the redesign fan-out after About (#28).

## What changed
- **New layout:** full-bleed `bg.canvas` band containing a teal gradient CTA card (`#12525e` → `#0e3038`) with a radial-glow `::before`, centered `h2` + lead copy, an amber email button, and two white-outline social buttons (LinkedIn, GitHub).
- **Legacy debt cleared:** dropped `bg="primary.base"` and the 4.29:1 `color="body"` contrast pin (the same pin About cleared). The canvas is now `bg.canvas` (`#0b1617`) where `fg` is 16.30:1.
- **`SocialLinksList` no longer used here** — replaced by the design's labeled button row. It stays in the repo (HeroSection still imports it).
- Extracts `ContactCard` (chakra styled component) for the gradient panel; white-outline social button styles kept local (single consumer, per theme.ts recipe-scoping).
- Uses `Flex as="section"` per the new house-style rule.

## i18n
`en` source only — **Crowdin re-sync stays approval-gated**:
- adopt the design's `reach-out-title` / `reach-out-desc` copy

## Stories
- add `ContactActions` pinning the three action hrefs (mailto, LinkedIn, GitHub)
- `Default` anchor guard unchanged (`#contact`)

## Verification
- Typecheck clean, ESLint clean (pre-commit)
- Story tests + axe green (local, :6007)
- Visual review signed off locally

## Notes for review
- **Every Contact story will diff in Chromatic** (redesign) — needs human accept.
- The CTA card gradient is **opaque** (solid hex endpoints), so unlike the About cards axe can actually measure text contrast over it — no "incomplete" here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)